### PR TITLE
Fixed 'TypeError: filepicker.extend is not a function' error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = [{
     }),
     new webpack.ProvidePlugin({
       filepicker: 'filepicker-js',
+      'window.filepicker': 'filepicker-js'
     })
   ]
 }, {


### PR DESCRIPTION
Removing this line: https://github.com/ZeroCho/react-filepicker/commit/da6e3f6dec7a3520654295e80b1c2be938eec5d8#diff-11e9f7f953edc64ba14b0cc350ae7b9dL42 caused `TypeError: filepicker.extend is not a function` on page load.