### PR TITLE
Added support for upload link instead of button

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ yourCallbackFunction(fpfiles) {
   // handle fpfiles or blob object
 }
 ```
+
+**Link instead of button**
+```
+<ReactFilepicker apikey={Your API Key} defaultWidget={false} link options={options} onSuccess={this.yourCallbackFunction} />
+```
+
 ## Result
 ![filestack](https://cloud.githubusercontent.com/assets/10962668/16173096/634160de-35d1-11e6-9b6a-1803b53c30d6.png)
 ## Demo

--- a/src/ReactFilepicker.js
+++ b/src/ReactFilepicker.js
@@ -25,6 +25,7 @@ class ReactFilepicker extends Component {
     blob: PropTypes.object,
     apikey: PropTypes.string.isRequired,
     defaultWidget: PropTypes.bool,
+    link: PropTypes.bool,
     mode: PropTypes.string,
     buttonText: PropTypes.string,
     buttonClass: PropTypes.string,
@@ -160,21 +161,23 @@ class ReactFilepicker extends Component {
   };
 
   render() {
-    const { defaultWidget, buttonClass, buttonText, options } = this.props;
+    const { defaultWidget, buttonClass, buttonText, link, options } = this.props;
     if (defaultWidget) {
       return (
         <input ref="target" type="filepicker" />
       )
     }
+    const Tag = link ? 'a' : 'button'
     return (
-      <button
+      <Tag
         name="filepicker"
         ref="fpButton"
         onClick={this.onClickPick}
         className={buttonClass || options.buttonClass}
+        href={link ? 'javascript:void(0)' : undefined}
       >
         {buttonText || options.buttonText}
-      </button>
+      </Tag>
     )
   }
 }


### PR DESCRIPTION
Sometimes a link looks better than a button. This PR allows to use `a` element instead of `button`.